### PR TITLE
Add ragdoll players and slower parachute holder

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Simple two-player arcade game implemented with [Pygame](https://www.pygame.org/).
 
-Players leap from a plane and battle over a shared parachute on the way down to a barnyard full of sheep.  The game now features simple stick-figure pilots, a cartoony airplane, sheep grazing near the barn, and basic synthesized sound effects for the plane, wind and impacts.
+Players leap from a plane and battle over a shared parachute on the way down to a barnyard full of sheep.  The pilots now flop about like rag dolls and whoever is holding the parachute bag clutches it in their arm and falls a bit slower.  The game also features a cartoony airplane, sheep grazing near the barn, and basic synthesized sound effects for the plane, wind and impacts.
 
 ## Controls
 - **Red player**: A/D (left/right), W/S (slower/faster fall)


### PR DESCRIPTION
## Summary
- Give players ragdoll-style limbs that flail as they fall
- Have parachute bag appear in a player's arm and slow their movement
- Describe ragdoll behaviour and slower parachute holder in README

## Testing
- `python -m py_compile parachute_joust.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0a275bee4832f8965ffd694c03520