### PR TITLE
Add wind visuals and cloud obstacles to Parachute Joust

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Simple two-player arcade game implemented with [Pygame](https://www.pygame.org/).
 
-Players leap from a plane and battle over a shared parachute on the way down to a barnyard full of sheep.  The pilots now flop about like rag dolls and whoever is holding the parachute bag clutches it in their arm and falls a bit slower.  The game also features a cartoony airplane, sheep grazing near the barn, and basic synthesized sound effects for the plane, wind and impacts.
+Players leap from a plane and battle over a shared parachute on the way down to a barnyard full of sheep.  The pilots now flop about like rag dolls through rushing wind, and whoever is holding the parachute bag clutches it in their arm and falls a bit slower.  The game also features sparse clouds that can obscure the action, a cartoony airplane, sheep grazing near the barn, and basic synthesized sound effects for the plane, wind and impacts.
 
 ## Controls
 - **Red player**: A/D (left/right), W/S (slower/faster fall)


### PR DESCRIPTION
## Summary
- Make parachute slow only horizontal movement so players fall at equal speed
- Add wind streak particles and drifting clouds that can obscure players
- Update README to describe new wind and cloud effects

## Testing
- `python -m py_compile parachute_joust.py`
- `timeout 5 env SDL_VIDEODRIVER=dummy python parachute_joust.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0a5159260832fa74f87ec587cd7e6